### PR TITLE
Fix usage with C++17

### DIFF
--- a/ev++.h
+++ b/ev++.h
@@ -352,7 +352,7 @@ namespace ev {
   struct dynamic_loop : loop_ref
   {
 
-    dynamic_loop (unsigned int flags = AUTO) throw (bad_loop)
+    dynamic_loop (unsigned int flags = AUTO) noexcept(false)
     : loop_ref (ev_loop_new (flags))
     {
       if (!EV_AX)
@@ -376,7 +376,7 @@ namespace ev {
 
   struct default_loop : loop_ref
   {
-    default_loop (unsigned int flags = AUTO) throw (bad_loop)
+    default_loop (unsigned int flags = AUTO) throw noexcept(false)
 #if EV_MULTIPLICITY
     : loop_ref (ev_default_loop (flags))
 #endif

--- a/ev++.h
+++ b/ev++.h
@@ -376,7 +376,7 @@ namespace ev {
 
   struct default_loop : loop_ref
   {
-    default_loop (unsigned int flags = AUTO) throw noexcept(false)
+    default_loop (unsigned int flags = AUTO) noexcept(false)
 #if EV_MULTIPLICITY
     : loop_ref (ev_default_loop (flags))
 #endif


### PR DESCRIPTION
When using with C++17 I got the following error:
ev++.h:355:46: error: ISO C++1z does not allow dynamic exception specifications
      dynamic_loop (unsigned int flags = AUTO) throw (bad_loop)

This patch fixes the error by replacing `throw (bad_loop)`
with `noexcept(false)`.